### PR TITLE
chore: use correct path for types in core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": {
-        "import": "./index.d.ts"
+        "import": "./dist/index.d.ts"
       },
       "browser": {
         "require": "./dist/browser/index.cjs.js",


### PR DESCRIPTION
## Summary

Adding the path into the types import (like is done with browser and default imports/require) fixes the issue that typescript does not find the necessary types.

## Related issue

- fixes https://github.com/BetterTyped/hyper-fetch/issues/71