### PR TITLE
docs: fix incorrect adapter options key in request

### DIFF
--- a/documentation/docs/documentation/02-core/request.mdx
+++ b/documentation/docs/documentation/02-core/request.mdx
@@ -104,7 +104,7 @@ Add them by:
 ```ts
 const request = client.createRequest()({
   endpoint: "/some-endpoint",
-  adapterOptions: { timeout: 1000, withCredentials: true },
+  options: { timeout: 1000, withCredentials: true },
 });
 ```
 


### PR DESCRIPTION
## Summary

The current docs are mentioning updating adapter options on a request via `adapterOptions` key. However, according to https://github.com/BetterTyped/hyper-fetch/blob/c1a40f583c5b2322e2c0d9a039b256e3adb2652c/packages/core/src/request/request.types.ts#L66 and https://github.com/BetterTyped/hyper-fetch/blob/c1a40f583c5b2322e2c0d9a039b256e3adb2652c/packages/core/src/request/request.ts#L59 this key is called only `options`.