### PR TITLE
Docs: Fix link from core/basics/authentication -> guides/core/basics/authentication

### DIFF
--- a/documentation/docs/core/client.mdx
+++ b/documentation/docs/core/client.mdx
@@ -131,7 +131,7 @@ export const getUsers = client.createRequest()({
   type="guides"
   title="Authentication guide"
   description="Learn how to set up authentication for your application"
-  to="//guides/core/basics/authentication"
+  to="/docs/guides/core/basics/authentication"
 />
 
 ---


### PR DESCRIPTION
I noticed that on https://hyperfetch.bettertyped.com/docs/core/basics/authentication, the LinkCard to the Authentication Guide is missing the `/docs/` prefix, so it ends up going to `https://guides/core/basics/authentication` instead of `https://HYPERFETCH.BETTERTYPED.COM/docs/guides/core/basics/authentication` (emphasis mine).
